### PR TITLE
fix: Fixing and improving LambdaApi based on real-world usage

### DIFF
--- a/docs/lambda_api/index.md
+++ b/docs/lambda_api/index.md
@@ -169,6 +169,29 @@ module.exports.index = async awsEvent => api.process( awsEvent );
 
 In that scenario, every time any handler throws `NotFoundError`, a response with status code 404 and body `'Sorry, record not found'` will be returned.
 
+#### Matching
+
+To define which handler is used, the declared handlers are compared using the `instanceof` operator. This will entice that an handler for `Error` would match any other error that extends `Error`, like `TypeError`:
+
+```js
+class NotFoundError extends Error {};
+
+api.addErrorHandler( { errorType: Error, code: 404, message: 'Sorry, record not found' } );
+```
+
+In the scenario above, if `NotFoundError` was thrown, the error handler would catch it, because its `class` inherits from Error.
+
+#### Order
+
+As with other handlers, the error handler only process the first error handler it matches.
+
+```js
+api.addErrorHandler( { errorType: NotFoundError, code: 404, message: 'Sorry, record not found' } );
+api.addErrorHandler( { errorType: Error, code: 500, message: 'Ops' } );
+```
+
+So in the example above, if `NotFoundError` was thrown, the first handler would catch it and return 404. The second handler would be ignored.
+
 #### Arguments
 |Name|Type|Description|Required|
 |-|-|-|-|

--- a/src/lambda_api/event.spec.js
+++ b/src/lambda_api/event.spec.js
@@ -3,60 +3,100 @@ const awsEventV1 = require( './fixtures/request_payload_v1.json' );
 const awsEventV2 = require( './fixtures/request_payload_v2.json' );
 
 describe( 'Event Spec', () => {
-  it( 'Should parse the AWS event v1', () => {
-    const event = new Event();
-    event.parseFromAwsEvent( awsEventV1 );
+  describe( 'AWS Event Payload v1', () => {
+    it( 'Should parse the event', () => {
+      const event = new Event();
+      event.parseFromAwsEvent( awsEventV1 );
 
-    expect( event ).toMatchObject( {
-      authorizer: { claims: null, scopes: null },
-      headers: {
-        header1: 'value1',
-        header2: 'value1,value2'
-      },
-      method: 'GET',
-      path: '/my/path/foo',
-      route: '/my/path/{var}',
-      params: { var: 'foo' },
-      queryString: {
-        parameter1: 'value1,value2',
-        parameter2: 'value'
-      },
-      body: 'Hello from Lambda!',
-      context: {}
+      expect( event ).toMatchObject( {
+        authorizer: { claims: null, scopes: null },
+        headers: {
+          header1: 'value1',
+          header2: 'value1,value2'
+        },
+        method: 'GET',
+        path: '/my/path/foo',
+        route: '/my/path/{var}',
+        params: { var: 'foo' },
+        queryString: {
+          parameter1: 'value1,value2',
+          parameter2: 'value'
+        },
+        body: 'Hello from Lambda!',
+        context: {}
+      } );
+    } );
+
+    it( 'Should initialize params, qs and headers as empty objectives if absent', () => {
+      const event = new Event();
+      event.parseFromAwsEvent( { version: '1.0' } );
+
+      expect( event ).toMatchObject( {
+        authorizer: undefined,
+        headers: {
+        },
+        method: undefined,
+        path: undefined,
+        route: undefined,
+        params: {},
+        queryString: {},
+        body: null,
+        context: {}
+      } );
     } );
   } );
 
-  it( 'Should parse the AWS event v2', () => {
-    const event = new Event();
-    event.parseFromAwsEvent( awsEventV2 );
+  describe( 'AWS Event Payload v2', () => {
+    it( 'Should parse the event', () => {
+      const event = new Event();
+      event.parseFromAwsEvent( awsEventV2 );
 
-    expect( event ).toMatchObject( {
-      authorizer: {
-        jwt: {
-          claims: {
-            claim1: 'value1',
-            claim2: 'value2'
-          },
-          scopes: [
-            'scope1',
-            'scope2'
-          ]
-        }
-      },
-      headers: {
-        header1: 'value1',
-        header2: 'value1,value2'
-      },
-      method: 'POST',
-      path: '/my/path/foo',
-      route: '/my/path/{var}',
-      params: { var: 'foo' },
-      queryString: {
-        parameter1: 'value1,value2',
-        parameter2: 'value'
-      },
-      body: 'Hello from Lambda',
-      context: {}
+      expect( event ).toMatchObject( {
+        authorizer: {
+          jwt: {
+            claims: {
+              claim1: 'value1',
+              claim2: 'value2'
+            },
+            scopes: [
+              'scope1',
+              'scope2'
+            ]
+          }
+        },
+        headers: {
+          header1: 'value1',
+          header2: 'value1,value2'
+        },
+        method: 'POST',
+        path: '/my/path/foo',
+        route: '/my/path/{var}',
+        params: { var: 'foo' },
+        queryString: {
+          parameter1: 'value1,value2',
+          parameter2: 'value'
+        },
+        body: 'Hello from Lambda',
+        context: {}
+      } );
+    } );
+
+    it( 'Should initialize params, qs and headers as empty objectives if absent', () => {
+      const event = new Event();
+      event.parseFromAwsEvent( { requestContext: { http: {} } } );
+
+      expect( event ).toMatchObject( {
+        authorizer: undefined,
+        headers: {
+        },
+        method: undefined,
+        path: undefined,
+        route: undefined,
+        params: {},
+        queryString: {},
+        body: null,
+        context: {}
+      } );
     } );
   } );
 

--- a/src/lambda_api/text_enum.js
+++ b/src/lambda_api/text_enum.js
@@ -1,7 +1,7 @@
 module.exports = {
   ERROR_500: 'Internal Server Error',
   ERROR_405: 'Method Not Allowed',
-  INVALID_ERROR_TYPE: 'Argument "errorType" must be an Object with a constructor',
+  INVALID_ERROR_TYPE: 'Argument "errorType" must be a constructor Function',
   INVALID_FN: 'Argument "fn" must be of type function',
   INVALID_METHOD: 'Argument "method" must be one of the default HTTP methods',
   INVALID_STATUS_CODE: 'Argument "statusCode" must be valid HTTP Status Code',
@@ -15,5 +15,5 @@ module.exports = {
   INVALID_MATCHER_PATH_INCLUDES: 'Argument "pathIncludes" must be either undefined or an string with length greater than 0',
   INVALID_MATCHER_PATH_NOT_INCLUDES: 'Argument "pathNotIncludes" must be either undefined or an string with length greater than 0',
   INVALID_MATCHER_PATH_MATCH: 'Argument "pathMatch" must be either undefined or type RegExp',
-  INVALID_USER_RESPONSE: 'Function return must be a number, a string, am array (where p=0 is a number) or an object (where .statusCode is a number)'
+  INVALID_USER_RESPONSE: 'Function return must be a number, a string, an array (where p=0 is a number) or an object (where .statusCode is a number)'
 };


### PR DESCRIPTION
## Changes
- Updating handler's "Event" to have its properties serializable';
- Updating error handling to match errors by `instanceof`;
- Updating documentation with the change above;
- Updating AWS event payload v1/v2 detection to  explicitly check for v1;
- Fixing messages typos;