### PR TITLE
Module timestreamQuery Improvements

### DIFF
--- a/docs/aws/timestream_query.md
+++ b/docs/aws/timestream_query.md
@@ -84,17 +84,20 @@ About the rows parsing, this is how the raw data is converted:
 |INTEGER|Number|`"10"`|`10`|
 |UNKNOWN|null|`<anything>`|`null`|
 |VARCHAR|String|`"string"`|`"string"`|
-|BIGINT|String|`"9223372036854775807"`|`"9223372036854775807"`|
+|BIGINT*|Number: when value is __between__ `MIN_SAFE_INTEGER` and `MAX_SAFE_INTEGER`|`"10"`|`10`|
+||String: when value is __beyond__ `MIN_SAFE_INTEGER` and `MAX_SAFE_INTEGER`|`"9007199254740992"`|`"9007199254740992"`|
 |DATE|String|`"2025-01-01"`|`"2025-01-01"`|
 |TIME|String|`"10:33:22.000000000"`|`"10:33:22.000000000"`|
-|INTERVAL_DAY_TO_SECOND|`"0 00:00:23.000000000"`|`"0 00:00:23.000000000"`|
-|INTERVAL_YEAR_TO_MONTH|`"1-11"`|`"1-11"`|
+|INTERVAL_DAY_TO_SECOND|String|`"0 00:00:23.000000000"`|`"0 00:00:23.000000000"`|
+|INTERVAL_YEAR_TO_MONTH|String|`"1-11"`|`"1-11"`|
 |_*Null Value*_|
 |* w/ `NullValue = true`|null|`undefined`|`null`|
-|_*Other Types*_|
+|_*Complex Types*_|
 |ARRAY|Array|`ARRAY[10,10]`|`[ 10, 10 ]`|
 |ROW|Object|`ROW(10,'bar')`|`{ field0: 10, field1: 'bar' }`|
 |TIME_SERIES|Array<Object>|`TIMESERIES(ARRAY[ROW(2025-01-01 10:00:00.000000000,10),ROW(2025-01-01 11:00:00.000000000),12]`|`[ { time: new Date( '2025-01-01T10:00' ), value: 10 }, { time: new Date( '2025-01-01T11:00', value: 12 } ]`|
+
+*: `BIGINT` will be returned as JS Number if its value lies between `Number.MIN_SAFE_INTEGER` and `Number.MAX_SAFE_INTEGER` [`-9007199254740991`, `9007199254740991`], otherwise a String representation of the number will be returned.
 
 #### Permissions needed
 

--- a/src/aws/timestream_query/parse_items.js
+++ b/src/aws/timestream_query/parse_items.js
@@ -3,6 +3,11 @@
 
 const { ScalarType } = require( '@aws-sdk/client-timestream-query' );
 
+const parseBigInt = value => {
+  const asInt = parseInt( value, 10 );
+  return asInt <= Number.MAX_SAFE_INTEGER && asInt >= Number.MIN_SAFE_INTEGER ? asInt : value;
+};
+
 const parseScalarValue = ( type, value ) => {
   switch ( type ) {
   case ScalarType.BOOLEAN:
@@ -15,8 +20,9 @@ const parseScalarValue = ( type, value ) => {
     return parseInt( value, 10 );
   case ScalarType.UNKNOWN: // is NULL
     return null;
-  case ScalarType.VARCHAR:
   case ScalarType.BIGINT:
+    return parseBigInt( value );
+  case ScalarType.VARCHAR:
   case ScalarType.DATE:
   case ScalarType.TIME:
   case ScalarType.INTERVAL_DAY_TO_SECOND:

--- a/src/aws/timestream_query/parse_items.spec.js
+++ b/src/aws/timestream_query/parse_items.spec.js
@@ -29,6 +29,48 @@ describe( 'Parse Items Spec', () => {
     ] );
   } );
 
+  describe( 'BigInt', () => {
+    it( 'Should convert big int to JS Number if it lies between MIN and MAX SAFE INTEGER', () => {
+      const result = parseItems( {
+        ColumnInfo: [ { Name: 'bigInt', Type: { ScalarType: 'BIGINT' } } ],
+        Rows: [ { Data: [ { ScalarValue: '10' } ] } ]
+      } );
+      expect( result ).toEqual( [ { bigInt: 10 } ] );
+    } );
+
+    it( 'Should convert big int to JS Number if it is exactly the MIN SAFE INTEGER', () => {
+      const result = parseItems( {
+        ColumnInfo: [ { Name: 'bigInt', Type: { ScalarType: 'BIGINT' } } ],
+        Rows: [ { Data: [ { ScalarValue: '-9007199254740991' } ] } ]
+      } );
+      expect( result ).toEqual( [ { bigInt: -9007199254740991 } ] );
+    } );
+
+    it( 'Should convert big int to JS Number if it is exactly the MAX SAFE INTEGER', () => {
+      const result = parseItems( {
+        ColumnInfo: [ { Name: 'bigInt', Type: { ScalarType: 'BIGINT' } } ],
+        Rows: [ { Data: [ { ScalarValue: '9007199254740991' } ] } ]
+      } );
+      expect( result ).toEqual( [ { bigInt: 9007199254740991 } ] );
+    } );
+
+    it( 'Should keep big int as String if it is below MIN SAFE INTEGER', () => {
+      const result = parseItems( {
+        ColumnInfo: [ { Name: 'bigInt', Type: { ScalarType: 'BIGINT' } } ],
+        Rows: [ { Data: [ { ScalarValue: '-9007199254740992' } ] } ]
+      } );
+      expect( result ).toEqual( [ { bigInt: '-9007199254740992' } ] );
+    } );
+
+    it( 'Should keep big int as String if it is above MAX SAFE INTEGER', () => {
+      const result = parseItems( {
+        ColumnInfo: [ { Name: 'bigInt', Type: { ScalarType: 'BIGINT' } } ],
+        Rows: [ { Data: [ { ScalarValue: '9007199254740992' } ] } ]
+      } );
+      expect( result ).toEqual( [ { bigInt: '9007199254740992' } ] );
+    } );
+  } );
+
   describe( 'Array', () => {
     it( 'Should parse array with scalar values', () => {
       const result = parseItems( responseArrayWithScalar );

--- a/src/aws/timestream_query/query.js
+++ b/src/aws/timestream_query/query.js
@@ -2,12 +2,20 @@ const { QueryCommand } = require( '@aws-sdk/client-timestream-query' );
 const { camelize } = require( '../../object' );
 const parseItems = require( './parse_items' );
 
-module.exports = async ( client, queryString, { paginationToken = undefined, maxRows = undefined, rawResponse = false } = {} ) => {
+const query = async ( client, queryString, { prevItems = [], recursive, paginationToken, maxRows, rawResponse } ) => {
   const response = await client.send( new QueryCommand( { QueryString: queryString, NextToken: paginationToken, MaxRows: maxRows } ) );
-  return rawResponse ? response : {
-    nextToken: response.NextToken,
-    count: response.Rows.length,
-    items: parseItems( response ),
-    queryStatus: camelize( response.QueryStatus )
-  };
+  if ( !recursive && rawResponse ) {
+    return response;
+  }
+
+  const nextToken = response.NextToken;
+  if ( nextToken && recursive ) {
+    return query( client, queryString, { prevItems: parseItems( response ), recursive, paginationToken: nextToken, maxRows } );
+  }
+
+  const items = prevItems.concat( parseItems( response ) );
+  return { nextToken, count: items.length, items, queryStatus: camelize( response.QueryStatus ) };
 };
+
+module.exports = async ( client, queryString, { recursive = false, paginationToken = undefined, maxRows = undefined, rawResponse = false } = {} ) =>
+  query( client, queryString, { recursive, paginationToken, maxRows, rawResponse } );


### PR DESCRIPTION
- Adding `recursive` option when using `timestreamQuery.query()` to return all pages (self pagination), same behavior as `athena.query` and `dynamo.query/scan`;
- Parsing Timestream `BIGINT` Scalar Values as Number if possible - value lies between `Number.MIN_SAFE_INTEGER` and `Number.MAX_SAFE_INTEGER` -, keep String otherwise;