### PR TITLE
Fixing lambda API event version detection and event v1 parsing

### DIFF
--- a/src/lambda_api/event.js
+++ b/src/lambda_api/event.js
@@ -31,7 +31,7 @@ module.exports = class Event {
   }
 
   parseFromAwsEvent( awsEvent ) {
-    this[`parseFromAwsEventV${awsEvent.version !== '1.0' ? 2 : 1}`]( awsEvent );
+    this[`parseFromAwsEventV${awsEvent.version === '2.0' ? 2 : 1}`]( awsEvent );
   }
 
   parseFromAwsEventV1( awsEvent ) {
@@ -49,12 +49,12 @@ module.exports = class Event {
     } = awsEvent;
 
     const unifiedHeaders = {
-      headers,
+      ...headers,
       ...Object.fromEntries( Object.entries( multiValueHeaders ?? {} ).map( ( [ k, v ] ) => [ k, Array.isArray( v ) ? v.join( ',' ) : k ] ) )
     };
 
     const unifiedQueryString = {
-      queryStringParameters,
+      ...queryStringParameters,
       ...Object.fromEntries( Object.entries( multiValueQueryString ?? {} ).map( ( [ k, v ] ) => [ k, Array.isArray( v ) ? v.join( ',' ) : k ] ) )
     };
 

--- a/src/lambda_api/event.spec.js
+++ b/src/lambda_api/event.spec.js
@@ -8,7 +8,7 @@ describe( 'Event Spec', () => {
       const event = new Event();
       event.parseFromAwsEvent( awsEventV1 );
 
-      expect( event ).toMatchObject( {
+      expect( event ).toEqual( {
         authorizer: { claims: null, scopes: null },
         headers: {
           header1: 'value1',
@@ -31,7 +31,7 @@ describe( 'Event Spec', () => {
       const event = new Event();
       event.parseFromAwsEvent( { version: '1.0' } );
 
-      expect( event ).toMatchObject( {
+      expect( event ).toEqual( {
         authorizer: undefined,
         headers: {
         },
@@ -51,7 +51,7 @@ describe( 'Event Spec', () => {
       const event = new Event();
       event.parseFromAwsEvent( awsEventV2 );
 
-      expect( event ).toMatchObject( {
+      expect( event ).toEqual( {
         authorizer: {
           jwt: {
             claims: {
@@ -85,7 +85,7 @@ describe( 'Event Spec', () => {
       const event = new Event();
       event.parseFromAwsEvent( { requestContext: { http: {} } } );
 
-      expect( event ).toMatchObject( {
+      expect( event ).toEqual( {
         authorizer: undefined,
         headers: {
         },


### PR DESCRIPTION
fix: Fixing lambda API event version detection and event v1 header/querystring parsing