### PR TITLE
Changing the sqs.sendMessageBatch native args structure

### DIFF
--- a/src/aws/sqs/send_message_batch.js
+++ b/src/aws/sqs/send_message_batch.js
@@ -7,10 +7,10 @@ module.exports = async ( client, queue, messages ) => {
   }
   const response = await client.send( new SendMessageBatchCommand( {
     QueueUrl: queue,
-    Entries: messages.map( ( { body, id = null, ...args }, index ) => ( {
-      ...args,
+    Entries: messages.map( ( { body, id = null, nativeArgs }, index ) => ( {
       Id: id ?? `message_${index}`,
-      MessageBody: sanitizeSqs( typeof body === 'string' ? body : JSON.stringify( body ) )
+      MessageBody: sanitizeSqs( typeof body === 'string' ? body : JSON.stringify( body ) ),
+      ...nativeArgs
     } ) )
   } ) );
 

--- a/src/aws/sqs/send_message_batch.spec.js
+++ b/src/aws/sqs/send_message_batch.spec.js
@@ -23,8 +23,13 @@ describe( 'SQS Send Message Batch Spec', () => {
     client.send.mockResolvedValue( { Successful: [], Failed: [] } );
 
     const result = await sendMessageBatch( client, 'sqs://mw.com', [ {
-      body: { foo: 'bar' },
-      DelaySeconds: 30
+      body: {
+        foo: 'bar'
+      },
+      nativeArgs: {
+        DelaySeconds: 30,
+        MessageDeduplicationId: '123'
+      }
     } ] );
 
     expect( result ).toEqual( { Successful: [], Failed: [] } );
@@ -33,6 +38,7 @@ describe( 'SQS Send Message Batch Spec', () => {
       Entries: [ {
         Id: 'message_0',
         MessageBody: '{"foo":"bar"}',
+        MessageDeduplicationId: '123',
         DelaySeconds: 30
       } ]
     } );


### PR DESCRIPTION
feat: Changing the `sqs.sendMessageBatch()` native args structure for each entry in the batch