### PR TITLE
feat: API Gateway encoding flag

### DIFF
--- a/docs/lambda_api/index.md
+++ b/docs/lambda_api/index.md
@@ -119,12 +119,13 @@ The return of handler's "fn" function. This will be used to compose the HTTP res
 |number|valid status code|value|_\<empty>_|_\<none>_|If the function's returns a number and it is a valid status code, the API will return it as the status code without a body|
 
 ##### Arrays
-If the function returns an array it has to contain up to three values in this schema: `[ statusCode, body*, headers* ]`:
+If the function returns an array it has to contain up to three values in this schema: `[ statusCode, body*, headers*, isBase64Encoded* ]`:
 |Position|Type|Required|Used As|Description|
 |-|-|-|-|-|
 |0|number|Yes|status code|The response HTTP status code|
 |1|any|-|body|The response body|
 |2|object|-|headers|Any additional headers to append to the response|
+|3|boolean|-|isBase64Encoded flag|Whether the `body` is encoded as a `base64` string or not|
 
 If the body is present it is handled as such:
 |Condition|Mime Type|Value|
@@ -136,12 +137,13 @@ If the body is present it is handled as such:
 For the headers, they are appended to the other headers. As this has the most precedence, they will overwrite any other header with the same name.
 
 ##### Objects
-If the function returns an object it has to contain up to three properties in this schema: `{ statusCode, body*, headers* }`:
+If the function returns an object it has to contain up to three properties in this schema: `{ statusCode, body*, headers*, isBase64Encoded* }`:
 |Property|Type|Required|Description|
 |-|-|-|-|
 |statusCode|number|Yes|The response HTTP status code|
 |body|any|-|The response body|
 |headers|object|-|Any additional headers to append to the response|
+|isBase64Encoded|boolean|-|Whether the `body` is encoded as a `base64` string or not|
 
 If the body is present it is handled the same way as it is for [Arrays](#arrays) responses, same for headers.
 
@@ -279,6 +281,7 @@ All properties in the object are __read-only__ excepts `context`. The `context` 
 |path|The HTTP request path|`path`|`requestContext.http.path`|String|
 |queryString|The HTTP URL query string|`queryStringParameters` + `multiValueQueryStringParameters`(3)|`queryStringParameters`|Object|
 |route|The route from its spec that the API Gateway matched this request|`resource`|`routeKey`(4)|String|
+|isBase64Encoded|Whether the `body` is encoded as a `base64` string or not|`isBase64Encoded`|`isBase64Encoded`|Boolean|
 
 1. the authorized content is not parsed so it will differs between API Gateway Payload v1 and v2.
 2. The `body` is automatically parsed to Object if it is a valid JSON.

--- a/src/lambda_api/api_response.js
+++ b/src/lambda_api/api_response.js
@@ -10,6 +10,7 @@ module.exports = class ApiResponse {
   #headers = null;
   #statusCode = null;
   #transformFn = false;
+  #isBase64Encoded = false;
   #body = '';
 
   constructor( { headers = {}, transform } = {} ) {
@@ -20,8 +21,9 @@ module.exports = class ApiResponse {
     }, headers );
   }
 
-  setContent( statusCode, body, headers = {} ) {
+  setContent( statusCode, body, headers = {}, isBase64Encoded = false ) {
     this.#statusCode = statusCode;
+    this.#isBase64Encoded = isBase64Encoded;
     if ( body?.length === 0 || [ null, undefined ].includes( body ) ) {
       this.#body = '';
     } else if ( typeof body === 'object' ) {
@@ -38,6 +40,7 @@ module.exports = class ApiResponse {
 
   toJSON() {
     return {
+      isBase64Encoded: this.#isBase64Encoded,
       statusCode: this.#statusCode,
       body: this.#body,
       headers: this.#headers

--- a/src/lambda_api/api_response.spec.js
+++ b/src/lambda_api/api_response.spec.js
@@ -5,6 +5,7 @@ describe( 'Lambda API: Api Response Spec', () => {
     const response = new ApiResponse();
     response.setContent( 200 );
     expect( response.toJSON() ).toEqual( {
+      isBase64Encoded: false,
       statusCode: 200,
       body: '',
       headers: {
@@ -19,6 +20,7 @@ describe( 'Lambda API: Api Response Spec', () => {
     const response = new ApiResponse();
     response.setContent( 200, 'Foo' );
     expect( response.toJSON() ).toEqual( {
+      isBase64Encoded: false,
       statusCode: 200,
       body: 'Foo',
       headers: {
@@ -35,6 +37,7 @@ describe( 'Lambda API: Api Response Spec', () => {
     response.setContent( 200, { color: 'red' } );
 
     expect( response.toJSON() ).toEqual( {
+      isBase64Encoded: false,
       statusCode: 200,
       body: '{"color":"red"}',
       headers: {
@@ -51,6 +54,7 @@ describe( 'Lambda API: Api Response Spec', () => {
     response.setContent( 200, { colorFamily: 'red' } );
 
     expect( response.toJSON() ).toEqual( {
+      isBase64Encoded: false,
       statusCode: 200,
       body: '{"color_family":"red"}',
       headers: {
@@ -67,6 +71,7 @@ describe( 'Lambda API: Api Response Spec', () => {
     response.setContent( 200, { color_family: 'red' } );
 
     expect( response.toJSON() ).toEqual( {
+      isBase64Encoded: false,
       statusCode: 200,
       body: '{"colorFamily":"red"}',
       headers: {
@@ -83,6 +88,7 @@ describe( 'Lambda API: Api Response Spec', () => {
     response.setContent( 200, { colorFamily: 'red' } );
 
     expect( response.toJSON() ).toEqual( {
+      isBase64Encoded: false,
       statusCode: 200,
       body: '{"colorFamily":"red"}',
       headers: {
@@ -100,6 +106,7 @@ describe( 'Lambda API: Api Response Spec', () => {
     response.setContent( 200, { colorFamily: 'red' }, { 'X-Foo': 'bar' } );
 
     expect( response.toJSON() ).toEqual( {
+      isBase64Encoded: false,
       statusCode: 200,
       body: '{"colorFamily":"red"}',
       headers: {
@@ -108,6 +115,23 @@ describe( 'Lambda API: Api Response Spec', () => {
         'Content-Type': 'application/json; charset=utf-8',
         'Content-Length': 21,
         'X-Foo': 'bar'
+      }
+    } );
+  } );
+
+  it( 'Should set the encoding flag according to the content', () => {
+    const response = new ApiResponse();
+    response.setContent( 200, 'eyJjb2xvckZhbWlseSI6InJlZCJ9', undefined, true );
+
+    expect( response.toJSON() ).toEqual( {
+      isBase64Encoded: true,
+      statusCode: 200,
+      body: 'eyJjb2xvckZhbWlseSI6InJlZCJ9',
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-store',
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Content-Length': 28
       }
     } );
   } );

--- a/src/lambda_api/event.js
+++ b/src/lambda_api/event.js
@@ -45,7 +45,8 @@ module.exports = class Event {
       headers,
       multiValueHeaders,
       queryStringParameters,
-      multiValueQueryStringParameters: multiValueQueryString
+      multiValueQueryStringParameters: multiValueQueryString,
+      isBase64Encoded
     } = awsEvent;
 
     const unifiedHeaders = {
@@ -66,6 +67,7 @@ module.exports = class Event {
     this.path = path;
     this.queryString = this.#transformFn( unifiedQueryString ) ?? {};
     this.route = resource;
+    this.isBase64Encoded = isBase64Encoded ?? false;
   }
 
   parseFromAwsEventV2( awsEvent ) {
@@ -75,7 +77,8 @@ module.exports = class Event {
       requestContext,
       pathParameters,
       headers,
-      queryStringParameters
+      queryStringParameters,
+      isBase64Encoded
     } = awsEvent;
 
     const { http: { method, path } } = requestContext;
@@ -88,5 +91,6 @@ module.exports = class Event {
     this.path = path;
     this.queryString = this.#transformFn( queryStringParameters ) ?? {};
     this.route = routeKey?.split( ' ' )[1].replace( /\/$/, '' );
+    this.isBase64Encoded = isBase64Encoded ?? false;
   }
 };

--- a/src/lambda_api/event.spec.js
+++ b/src/lambda_api/event.spec.js
@@ -23,11 +23,12 @@ describe( 'Event Spec', () => {
           parameter2: 'value'
         },
         body: 'Hello from Lambda!',
-        context: {}
+        context: {},
+        isBase64Encoded: false
       } );
     } );
 
-    it( 'Should initialize params, qs and headers as empty objectives if absent', () => {
+    it( 'Should initialize params, qs and headers as empty objects and encoding as false if absent', () => {
       const event = new Event();
       event.parseFromAwsEvent( { version: '1.0' } );
 
@@ -41,7 +42,8 @@ describe( 'Event Spec', () => {
         params: {},
         queryString: {},
         body: null,
-        context: {}
+        context: {},
+        isBase64Encoded: false
       } );
     } );
   } );
@@ -77,11 +79,12 @@ describe( 'Event Spec', () => {
           parameter2: 'value'
         },
         body: 'Hello from Lambda',
-        context: {}
+        context: {},
+        isBase64Encoded: false
       } );
     } );
 
-    it( 'Should initialize params, qs and headers as empty objectives if absent', () => {
+    it( 'Should initialize params, qs and headers as empty objects and encoding as false if absent', () => {
       const event = new Event();
       event.parseFromAwsEvent( { requestContext: { http: {} } } );
 
@@ -95,7 +98,8 @@ describe( 'Event Spec', () => {
         params: {},
         queryString: {},
         body: null,
-        context: {}
+        context: {},
+        isBase64Encoded: false
       } );
     } );
   } );

--- a/src/lambda_api/user_response.js
+++ b/src/lambda_api/user_response.js
@@ -22,7 +22,7 @@ module.exports = class UserResponse {
 
     } else if ( args.statusCode ) {
       validators.statusCode( args.statusCode );
-      this.values = [ args.statusCode, args.body, args.headers ];
+      this.values = [ args.statusCode, args.body, args.headers, args.isBase64Encoded ];
 
     } else if ( [ undefined, null ].includes( args ) ) {
       this.values = [ 200 ];

--- a/src/lambda_api/user_response.spec.js
+++ b/src/lambda_api/user_response.spec.js
@@ -21,9 +21,9 @@ describe( 'User Response Spec', () => {
     expect( response.values ).toEqual( [ 204 ] );
   } );
 
-  it( 'Should accept an array, where positions are status code, body, headers, respectively', () => {
-    const response = new UserResponse( [ 304, 'foo', { 'X-header': 'Bar' } ] );
-    expect( response.values ).toEqual( [ 304, 'foo', { 'X-header': 'Bar' } ] );
+  it( 'Should accept an array, where positions are status code, body, headers, isBase64Encoded respectively', () => {
+    const response = new UserResponse( [ 304, 'foo', { 'X-header': 'Bar' }, false ] );
+    expect( response.values ).toEqual( [ 304, 'foo', { 'X-header': 'Bar' }, false ] );
   } );
 
   it( 'Should accept an array with just one position, status code', () => {
@@ -31,9 +31,9 @@ describe( 'User Response Spec', () => {
     expect( response.values ).toEqual( [ 304 ] );
   } );
 
-  it( 'Should accept an object, with the following properties: statusCode, body, headers', () => {
-    const response = new UserResponse( { statusCode: 304, body: 'foo', headers: { 'X-header': 'Bar' } } );
-    expect( response.values ).toEqual( [ 304, 'foo', { 'X-header': 'Bar' } ] );
+  it( 'Should accept an object, with the following properties: statusCode, body, headers and isBase64Encoded', () => {
+    const response = new UserResponse( { statusCode: 304, body: 'foo', headers: { 'X-header': 'Bar' }, isBase64Encoded: true } );
+    expect( response.values ).toEqual( [ 304, 'foo', { 'X-header': 'Bar' }, true ] );
   } );
 
   it( 'Should accept an object, with just statusCode', () => {


### PR DESCRIPTION
- Parse and expose the `isBase64Encoded` flag from the API Gateway request event (both V1 and V2)
- Allows consumers to set the `isBase64Encoded` flag on the response of each handler (default is false)
- Docs: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format