### PR TITLE
feat: new S3 functions

### DIFF
--- a/docs/aws/s3.md
+++ b/docs/aws/s3.md
@@ -9,6 +9,7 @@ Namespace: `aws.s3.`
 - [`fn` copy](#fn-copy)
 - [`fn` download](#fn-download)
 - [`fn` getSignedDownloadUrl](#fn-getsigneddownloadurl)
+- [`fn` getSignedPostUrl](#fn-getsignedposturl)
 - [`fn` getSignedUploadUrl](#fn-getsigneduploadurl)
 - [`fn` getSignedUrl (deprecated)](#fn-getsignedurl)
 - [`fn` head](#fn-head)
@@ -175,6 +176,60 @@ The AWS policy statement to use this function is:
       "Effect": "Allow",
       "Action": [
         "s3:GetObject"
+      ],
+      "Resource": [
+        "<bucket arn>/*"
+      ]
+    }
+  ]
+}
+```
+
+### `fn` getSignedPostUrl
+
+Creates a signed S3 object post url. Abstracts the `@aws-sdk/s3-presigned-post`'s `createPresignedPost` function.
+
+```js
+// CJS
+const { aws: { s3 } } = require( 'lambda-toolkit' );
+
+// ESM
+import { aws } from 'lambda-toolkit';
+const { s3 } = aws;
+
+const url = await s3.getSignedPostUrl( 'my-bucket', 'my/key.json', 360 );
+console.log( url );
+
+// With native args
+const url = await s3.getSignedPostUrl( 'my-bucket', 'my/key.json', 360, { Fields: { ... }, Conditions: [ ... ] } );
+console.log( url );
+```
+
+#### Arguments
+
+|Name|Type|Description|Default|
+|---|---|---|---|
+|bucket|String|The the s3 bucket of the object to download||
+|key|String|The the s3 key of the object to download||
+|expiration|number|The number of seconds before the presigned URL expires||
+|nativeArgs|Object|All `client-s3` SDK [createPresignedPost arguments](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-s3-presigned-post/) except `Key`, `Bucket` and `Expires`, which are defined by the previous arguments||
+
+#### Return
+
+The pre-signed post url of the S3 Object.
+
+#### Permissions needed
+
+The AWS policy statement to use this function is:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
       ],
       "Resource": [
         "<bucket arn>/*"

--- a/docs/aws/s3.md
+++ b/docs/aws/s3.md
@@ -8,7 +8,9 @@ Namespace: `aws.s3.`
 - [client](#client)
 - [`fn` copy](#fn-copy)
 - [`fn` download](#fn-download)
-- [`fn` getSignedUrl](#fn-getsignedurl)
+- [`fn` getSignedDownloadUrl](#fn-getsigneddownloadurl)
+- [`fn` getSignedUploadUrl](#fn-getsigneduploadurl)
+- [`fn` getSignedUrl (deprecated)](#fn-getsignedurl)
 - [`fn` head](#fn-head)
 - [`fn` upload](#fn-upload)
 
@@ -133,9 +135,9 @@ The AWS policy statement to use this function is:
 }
 ```
 
-### `fn` getSignedUrl
+### `fn` getSignedDownloadUrl
 
-Creates a signed S3 object url. Abstracts the `GetObjectCommand` and `@aws-sdk/s3-request-presigner`'s `getSignedUrl` functions.
+Creates a signed S3 object download url. Abstracts the `GetObjectCommand` and `@aws-sdk/s3-request-presigner`'s `getSignedUrl` functions.
 
 ```js
 // CJS
@@ -145,7 +147,7 @@ const { aws: { s3 } } = require( 'lambda-toolkit' );
 import { aws } from 'lambda-toolkit';
 const { s3 } = aws;
 
-const url = await s3.getSignedUrl( 'my-bucket', 'my/key.json', 360 );
+const url = await s3.getSignedDownloadUrl( 'my-bucket', 'my/key.json', 360 );
 console.log( url );
 ```
 
@@ -159,7 +161,7 @@ console.log( url );
 
 #### Return
 
-The pre-signed url of the S3 Object.
+The pre-signed download url of the S3 Object.
 
 #### Permissions needed
 
@@ -181,6 +183,64 @@ The AWS policy statement to use this function is:
   ]
 }
 ```
+
+### `fn` getSignedUploadUrl
+
+Creates a signed S3 object upload url. Abstracts the `PutObjectCommand` and `@aws-sdk/s3-request-presigner`'s `getSignedUrl` functions.
+
+```js
+// CJS
+const { aws: { s3 } } = require( 'lambda-toolkit' );
+
+// ESM
+import { aws } from 'lambda-toolkit';
+const { s3 } = aws;
+
+const url = await s3.getSignedUploadUrl( 'my-bucket', 'my/key.json', 360 );
+console.log( url );
+
+// With native args
+const url = await s3.getSignedUploadUrl( 'my-bucket', 'my/key.json', 360, { ContentType: 'application/json' } );
+console.log( url );
+```
+
+#### Arguments
+
+|Name|Type|Description|Default|
+|---|---|---|---|
+|bucket|String|The the s3 bucket of the object to download||
+|key|String|The the s3 key of the object to download||
+|expiration|number|The number of seconds before the presigned URL expires||
+|nativeArgs|Object|All `client-s3` SDK [PutObjectCommand arguments](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-s3/Class/PutObjectCommand/) except `Key` and `Bucket`, which are defined by the previous arguments||
+
+#### Return
+
+The pre-signed upload url of the S3 Object.
+
+#### Permissions needed
+
+The AWS policy statement to use this function is:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "<bucket arn>/*"
+      ]
+    }
+  ]
+}
+```
+
+### `fn` getSignedUrl
+
+This functions is deprecated. Use the [getSignedDownloadUrl](#fn-getsigneddownloadurl) function instead.
 
 ### `fn` head
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-toolkit",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "A set of tools to help and simplify Node Js code development for AWS Lambdas",
   "keywords": [
     "AWS",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@aws-sdk/client-timestream-query": ">=3.900.0 <4.0.0",
     "@aws-sdk/client-timestream-write": ">=3.900.0 <4.0.0",
     "@aws-sdk/lib-dynamodb": ">=3.900.0 <4.0.0",
+    "@aws-sdk/s3-presigned-post": ">=3.900.0 <4.0.0",
     "@aws-sdk/s3-request-presigner": ">=3.900.0 <4.0.0"
   },
   "devDependencies": {
@@ -77,6 +78,7 @@
     "@aws-sdk/client-timestream-query": "3.1018.0",
     "@aws-sdk/client-timestream-write": "3.1018.0",
     "@aws-sdk/lib-dynamodb": "3.1018.0",
+    "@aws-sdk/s3-presigned-post": "3.1018.0",
     "@aws-sdk/s3-request-presigner": "3.1018.0",
     "@eslint/js": "10.0.1",
     "@stylistic/eslint-plugin": "5.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@aws-sdk/lib-dynamodb':
         specifier: 3.1018.0
         version: 3.1018.0(@aws-sdk/client-dynamodb@3.1018.0)
+      '@aws-sdk/s3-presigned-post':
+        specifier: 3.1018.0
+        version: 3.1018.0
       '@aws-sdk/s3-request-presigner':
         specifier: 3.1018.0
         version: 3.1018.0
@@ -249,6 +252,10 @@ packages:
 
   '@aws-sdk/region-config-resolver@3.972.13':
     resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-presigned-post@3.1018.0':
+    resolution: {integrity: sha512-eC6AuaFnC5mnDygsJMyCn0oNy3K75bbK4nWOfEWsMsVhk3pL8fAQsxjDS1uEzlaBU89t40Nm/DfN36KceRXT7A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/s3-request-presigner@3.1018.0':
@@ -2138,6 +2145,20 @@ snapshots:
       '@smithy/node-config-provider': 4.4.1
       '@smithy/types': 4.14.1
       tslib: 2.8.1
+
+  '@aws-sdk/s3-presigned-post@3.1018.0':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1018.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-format-url': 3.972.10
+      '@smithy/middleware-endpoint': 4.5.1
+      '@smithy/signature-v4': 5.4.1
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.3.1
+      '@smithy/util-utf8': 4.3.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/s3-request-presigner@3.1018.0':
     dependencies:

--- a/src/aws/s3/get_signed_download_url.js
+++ b/src/aws/s3/get_signed_download_url.js
@@ -1,0 +1,8 @@
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+
+export const getSignedDownloadUrl = async ( client, bucket, key, expiration ) => {
+  const getObjectCmd = new GetObjectCommand( { Bucket: bucket, Key: key } );
+  const url = await getSignedUrl( client, getObjectCmd, { expiresIn: expiration } );
+  return url;
+};

--- a/src/aws/s3/get_signed_download_url.test.js
+++ b/src/aws/s3/get_signed_download_url.test.js
@@ -1,0 +1,59 @@
+import { describe, it, mock, beforeEach, afterEach } from 'node:test';
+import { strictEqual, deepStrictEqual } from 'node:assert';
+
+const commandInstance = {};
+const constructorMock = mock.fn( () => commandInstance );
+
+mock.module( '@aws-sdk/client-s3', {
+  namedExports: {
+    GetObjectCommand: new Proxy( class GetObjectCommand {}, {
+      construct( _, args ) {
+        return constructorMock( ...args );
+      }
+    } )
+  }
+} );
+
+const getSignedUrlMock = mock.fn();
+
+mock.module( '@aws-sdk/s3-request-presigner', {
+  namedExports: {
+    getSignedUrl: getSignedUrlMock
+  }
+} );
+
+const { getSignedDownloadUrl } = await import( './get_signed_download_url.js' );
+
+const client = {
+  send: mock.fn()
+};
+
+const bucket = 'bucket';
+const key = 'key';
+const expiration = 360;
+const response = 'htts://my-signed-url';
+
+describe( 'S3 Get Signed Download Url Spec', () => {
+  beforeEach( () => {
+    constructorMock.mock.mockImplementation( () => commandInstance );
+  } );
+
+  afterEach( () => {
+    mock.restoreAll();
+    client.send.mock.resetCalls();
+    constructorMock.mock.resetCalls();
+    getSignedUrlMock.mock.resetCalls();
+  } );
+
+  it( 'Should get a signed download url for a file from S3 and return its content', async () => {
+    getSignedUrlMock.mock.mockImplementation( () => response );
+
+    const result = await getSignedDownloadUrl( client, bucket, key, expiration );
+
+    strictEqual( result, response );
+    strictEqual( constructorMock.mock.calls.length, 1 );
+    deepStrictEqual( constructorMock.mock.calls[0].arguments[0], { Key: key, Bucket: bucket } );
+    strictEqual( getSignedUrlMock.mock.calls.length, 1 );
+    deepStrictEqual( getSignedUrlMock.mock.calls[0].arguments, [ client, commandInstance, { expiresIn: expiration } ] );
+  } );
+} );

--- a/src/aws/s3/get_signed_post_url.js
+++ b/src/aws/s3/get_signed_post_url.js
@@ -1,0 +1,11 @@
+import { createPresignedPost } from '@aws-sdk/s3-presigned-post';
+
+export const getSignedPostUrl = async ( client, bucket, key, expiration, nativeArgs ) => {
+  const url = await createPresignedPost( client, {
+    ...nativeArgs,
+    Bucket: bucket,
+    Key: key,
+    Expires: expiration
+  } );
+  return url;
+};

--- a/src/aws/s3/get_signed_post_url.test.js
+++ b/src/aws/s3/get_signed_post_url.test.js
@@ -1,0 +1,56 @@
+import { describe, it, mock, afterEach } from 'node:test';
+import { strictEqual, deepStrictEqual } from 'node:assert';
+
+const createPresignedPostMock = mock.fn();
+
+mock.module( '@aws-sdk/s3-presigned-post', {
+  namedExports: {
+    createPresignedPost: createPresignedPostMock
+  }
+} );
+
+const { getSignedPostUrl } = await import( './get_signed_post_url.js' );
+
+const client = {};
+
+const bucket = 'bucket';
+const key = 'key';
+const expiration = 360;
+const response = 'htts://my-signed-url';
+const fields = {
+  success_action_status: '204'
+};
+const conditions = [
+  [ 'eq', '$success_action_status', '204' ],
+  [ 'content-length-range', 0, 1048576 ]
+];
+
+describe( 'S3 Get Signed Post Url Spec', () => {
+  afterEach( () => {
+    mock.restoreAll();
+    createPresignedPostMock.mock.resetCalls();
+  } );
+
+  it( 'Should get a signed post url for a file from S3 and return its content', async () => {
+    createPresignedPostMock.mock.mockImplementation( () => response );
+
+    const result = await getSignedPostUrl( client, bucket, key, expiration );
+
+    strictEqual( result, response );
+    strictEqual( createPresignedPostMock.mock.calls.length, 1 );
+    deepStrictEqual( createPresignedPostMock.mock.calls[0].arguments, [ client, { Bucket: bucket, Key: key, Expires: expiration } ] );
+  } );
+
+  it( 'Should get a signed post url for a file from S3 with native args and return its content', async () => {
+    createPresignedPostMock.mock.mockImplementation( () => response );
+
+    const result = await getSignedPostUrl( client, bucket, key, expiration, { Fields: fields, Conditions: conditions } );
+
+    strictEqual( result, response );
+    strictEqual( createPresignedPostMock.mock.calls.length, 1 );
+    deepStrictEqual( createPresignedPostMock.mock.calls[0].arguments, [
+      client,
+      { Bucket: bucket, Key: key, Expires: expiration, Fields: fields, Conditions: conditions }
+    ] );
+  } );
+} );

--- a/src/aws/s3/get_signed_upload_url.js
+++ b/src/aws/s3/get_signed_upload_url.js
@@ -1,0 +1,12 @@
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+
+export const getSignedUploadUrl = async ( client, bucket, key, expiration, nativeArgs ) => {
+  const putObjectCmd = new PutObjectCommand( {
+    ...nativeArgs,
+    Bucket: bucket,
+    Key: key
+  } );
+  const url = await getSignedUrl( client, putObjectCmd, { expiresIn: expiration } );
+  return url;
+};

--- a/src/aws/s3/get_signed_upload_url.test.js
+++ b/src/aws/s3/get_signed_upload_url.test.js
@@ -6,7 +6,7 @@ const constructorMock = mock.fn( () => commandInstance );
 
 mock.module( '@aws-sdk/client-s3', {
   namedExports: {
-    GetObjectCommand: new Proxy( class GetObjectCommand {}, {
+    PutObjectCommand: new Proxy( class PutObjectCommand {}, {
       construct( _, args ) {
         return constructorMock( ...args );
       }
@@ -22,7 +22,7 @@ mock.module( '@aws-sdk/s3-request-presigner', {
   }
 } );
 
-const { getSignedUrl } = await import( './get_signed_url.js' );
+const { getSignedUploadUrl } = await import( './get_signed_upload_url.js' );
 
 const client = {
   send: mock.fn()
@@ -30,10 +30,11 @@ const client = {
 
 const bucket = 'bucket';
 const key = 'key';
+const contentType = 'application/json';
 const expiration = 360;
 const response = 'htts://my-signed-url';
 
-describe( 'S3 Get Signed Url Spec', () => {
+describe( 'S3 Get Signed Upload Url Spec', () => {
   beforeEach( () => {
     constructorMock.mock.mockImplementation( () => commandInstance );
   } );
@@ -45,14 +46,26 @@ describe( 'S3 Get Signed Url Spec', () => {
     getSignedUrlMock.mock.resetCalls();
   } );
 
-  it( 'Should getSignedUrl a file from S3 and return its content', async () => {
+  it( 'Should get a signed upload url for a file from S3 and return its content', async () => {
     getSignedUrlMock.mock.mockImplementation( () => response );
 
-    const result = await getSignedUrl( client, bucket, key, expiration );
+    const result = await getSignedUploadUrl( client, bucket, key, expiration );
 
     strictEqual( result, response );
     strictEqual( constructorMock.mock.calls.length, 1 );
     deepStrictEqual( constructorMock.mock.calls[0].arguments[0], { Key: key, Bucket: bucket } );
+    strictEqual( getSignedUrlMock.mock.calls.length, 1 );
+    deepStrictEqual( getSignedUrlMock.mock.calls[0].arguments, [ client, commandInstance, { expiresIn: expiration } ] );
+  } );
+
+  it( 'Should get a signed upload url for a file from S3 with native args and return its content', async () => {
+    getSignedUrlMock.mock.mockImplementation( () => response );
+
+    const result = await getSignedUploadUrl( client, bucket, key, expiration, { ContentType: contentType } );
+
+    strictEqual( result, response );
+    strictEqual( constructorMock.mock.calls.length, 1 );
+    deepStrictEqual( constructorMock.mock.calls[0].arguments[0], { Key: key, Bucket: bucket, ContentType: contentType } );
     strictEqual( getSignedUrlMock.mock.calls.length, 1 );
     deepStrictEqual( getSignedUrlMock.mock.calls[0].arguments, [ client, commandInstance, { expiresIn: expiration } ] );
   } );

--- a/src/aws/s3/get_signed_url.js
+++ b/src/aws/s3/get_signed_url.js
@@ -1,8 +1,6 @@
-import { getSignedUrl as getSignedUrlS3 } from '@aws-sdk/s3-request-presigner';
-import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedDownloadUrl } from './get_signed_download_url.js';
 
-export const getSignedUrl = async ( client, bucket, key, expiration ) => {
-  const getObjectCmd = new GetObjectCommand( { Bucket: bucket, Key: key } );
-  const url = await getSignedUrlS3( client, getObjectCmd, { expiresIn: expiration } );
-  return url;
-};
+/**
+ * @deprecated Use the getSignedDownloadUrl function instead
+ */
+export const getSignedUrl = async ( client, bucket, key, expiration ) => getSignedDownloadUrl( client, bucket, key, expiration );

--- a/src/aws/s3/index.js
+++ b/src/aws/s3/index.js
@@ -1,5 +1,8 @@
 import { copy } from './copy.js';
 import { download } from './download.js';
+import { getSignedDownloadUrl } from './get_signed_download_url.js';
+import { getSignedPostUrl } from './get_signed_post_url.js';
+import { getSignedUploadUrl } from './get_signed_upload_url.js';
 import { getSignedUrl } from './get_signed_url.js';
 import { head } from './head.js';
 import { upload } from './upload.js';
@@ -10,6 +13,9 @@ import { createInstance } from '../core/create_instance.js';
 const methods = {
   copy,
   download,
+  getSignedDownloadUrl,
+  getSignedPostUrl,
+  getSignedUploadUrl,
   getSignedUrl,
   head,
   upload


### PR DESCRIPTION
- 3 new S3 functions:
  - `getSignedDownloadUrl`: replaces the existing `getSignedUrl`
  - `getSignedUploadUrl`: abstracts the `PutObjectCommand` and `@aws-sdk/s3-request-presigner`'s `getSignedUrl` function
  - `getSignedPostUrl`: abstracts the `@aws-sdk/s3-presigned-post`'s `createPresignedPost` functions
    - https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-s3-presigned-post/
    - https://www.npmjs.com/package/@aws-sdk/s3-presigned-post 