### PR TITLE
feat: Support native args on S3 download

### DIFF
--- a/docs/aws/s3.md
+++ b/docs/aws/s3.md
@@ -204,6 +204,10 @@ const { s3 } = aws;
 
 const url = await s3.getSignedDownloadUrl( 'my-bucket', 'my/key.json', 360 );
 console.log( url );
+
+// With native args — force download with a filename hint
+const url = await s3.getSignedDownloadUrl( 'my-bucket', 'my/key.json', 360, { ResponseContentDisposition: 'attachment; filename="test.txt"' } );
+console.log( url );
 ```
 
 #### Arguments
@@ -213,6 +217,7 @@ console.log( url );
 |bucket|String|The the s3 bucket of the object to download||
 |key|String|The the s3 key of the object to download||
 |expiration|number|The number of seconds before the presigned URL expires||
+|nativeArgs|Object|All `client-s3` SDK [GetObjectCommand arguments](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-s3/Class/GetObjectCommand/) except `Key` and `Bucket`, which are defined by the previous arguments||
 
 #### Return
 

--- a/docs/aws/s3.md
+++ b/docs/aws/s3.md
@@ -206,7 +206,7 @@ const url = await s3.getSignedDownloadUrl( 'my-bucket', 'my/key.json', 360 );
 console.log( url );
 
 // With native args
-const url = await s3.getSignedDownloadUrl( 'my-bucket', 'my/key.json', 360, { ResponseContentDisposition: 'attachment; filename="test.txt"' } );
+const url = await s3.getSignedDownloadUrl( 'my-bucket', 'my/key.json', 360, { ResponseContentDisposition: 'attachment; filename="key.json"' } );
 console.log( url );
 ```
 

--- a/docs/aws/s3.md
+++ b/docs/aws/s3.md
@@ -205,7 +205,7 @@ const { s3 } = aws;
 const url = await s3.getSignedDownloadUrl( 'my-bucket', 'my/key.json', 360 );
 console.log( url );
 
-// With native args — force download with a filename hint
+// With native args
 const url = await s3.getSignedDownloadUrl( 'my-bucket', 'my/key.json', 360, { ResponseContentDisposition: 'attachment; filename="test.txt"' } );
 console.log( url );
 ```

--- a/src/aws/s3/get_signed_download_url.js
+++ b/src/aws/s3/get_signed_download_url.js
@@ -1,8 +1,12 @@
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 
-export const getSignedDownloadUrl = async ( client, bucket, key, expiration ) => {
-  const getObjectCmd = new GetObjectCommand( { Bucket: bucket, Key: key } );
+export const getSignedDownloadUrl = async ( client, bucket, key, expiration, nativeArgs ) => {
+  const getObjectCmd = new GetObjectCommand( {
+    ...nativeArgs,
+    Bucket: bucket,
+    Key: key
+  } );
   const url = await getSignedUrl( client, getObjectCmd, { expiresIn: expiration } );
   return url;
 };

--- a/src/aws/s3/get_signed_download_url.test.js
+++ b/src/aws/s3/get_signed_download_url.test.js
@@ -60,7 +60,7 @@ describe( 'S3 Get Signed Download Url Spec', () => {
   it( 'Should get a signed download url for a file from S3 with native args and return its content', async () => {
     getSignedUrlMock.mock.mockImplementation( () => response );
 
-    const contentDisposition = 'attachment; filename="test.txt"';
+    const contentDisposition = 'attachment; filename="key"';
     const result = await getSignedDownloadUrl( client, bucket, key, expiration, { ResponseContentDisposition: contentDisposition } );
 
     strictEqual( result, response );

--- a/src/aws/s3/get_signed_download_url.test.js
+++ b/src/aws/s3/get_signed_download_url.test.js
@@ -56,4 +56,17 @@ describe( 'S3 Get Signed Download Url Spec', () => {
     strictEqual( getSignedUrlMock.mock.calls.length, 1 );
     deepStrictEqual( getSignedUrlMock.mock.calls[0].arguments, [ client, commandInstance, { expiresIn: expiration } ] );
   } );
+
+  it( 'Should get a signed download url for a file from S3 with native args and return its content', async () => {
+    getSignedUrlMock.mock.mockImplementation( () => response );
+
+    const contentDisposition = 'attachment; filename="test.txt"';
+    const result = await getSignedDownloadUrl( client, bucket, key, expiration, { ResponseContentDisposition: contentDisposition } );
+
+    strictEqual( result, response );
+    strictEqual( constructorMock.mock.calls.length, 1 );
+    deepStrictEqual( constructorMock.mock.calls[0].arguments[0], { Key: key, Bucket: bucket, ResponseContentDisposition: contentDisposition } );
+    strictEqual( getSignedUrlMock.mock.calls.length, 1 );
+    deepStrictEqual( getSignedUrlMock.mock.calls[0].arguments, [ client, commandInstance, { expiresIn: expiration } ] );
+  } );
 } );


### PR DESCRIPTION
- Allows passing native args to the `s3.getSignedDownloadUrl` function