### PR TITLE
fix: run registered HEAD handler instead of always returning default 204

### DIFF
--- a/docs/lambda_api/index.md
+++ b/docs/lambda_api/index.md
@@ -47,7 +47,9 @@ The LambdaAPI does not throws error. If any error happens within any handler, it
 
 ## HEAD request
 
-Requests using HTTP verb `HEAD` are handled different, they don't try to match handlers, they will always return `204 <empty>`.
+Requests using HTTP verb `HEAD` are handled different by default: if no handler is registered for `HEAD`, they will always return `204 <empty>` without trying to match any other handler.
+
+If you register a handler for `HEAD` (via `.addHandler( { method: 'HEAD', ... } )`), it takes precedence and is invoked normally, just like any other verb.
 
 ## Constructor
 

--- a/src/lambda_api/lambda_api.js
+++ b/src/lambda_api/lambda_api.js
@@ -97,12 +97,12 @@ export class LambdaApi {
     const event = new Event( { transform: this.#transformRequest } );
     event.parseFromAwsEvent( awsEvent );
 
-    if ( event.method === 'HEAD' ) {
-      return this.#apiResponse.setContent( 204 ).toJSON();
-    }
-
     const handler = this.#handlers.find( h => h.match( event ) );
     if ( !handler ) {
+      if ( event.method === 'HEAD' ) {
+        return this.#apiResponse.setContent( 204 ).toJSON();
+      }
+
       return this.#apiResponse.setContent( 405, Text.ERROR_405 ).toJSON();
     }
 

--- a/src/lambda_api/lambda_api.test.js
+++ b/src/lambda_api/lambda_api.test.js
@@ -268,4 +268,37 @@ describe( 'Api Spec', () => {
       strictEqual( control.mock.calls.length, 0 );
     } );
   } );
+
+  describe( 'HEAD request', () => {
+    const headEvent = {
+      version: '2.0',
+      requestContext: {
+        http: {
+          method: 'HEAD',
+          path: '/'
+        }
+      }
+    };
+
+    it( 'Should return HTTP 204 by default when no handler is registered for HEAD', async () => {
+      const api = new LambdaApi();
+      api.addHandler( { method: 'GET', fn: _ => 200 } );
+
+      const result = await api.process( headEvent );
+      partialDeepStrictEqual( result, { statusCode: 204 } );
+    } );
+
+    it( 'Should invoke a registered HEAD handler instead of the default response', async () => {
+      const api = new LambdaApi();
+      api.addHandler( { method: 'HEAD', fn: _ => [ 200, '', { 'Content-Length': '42' } ] } );
+
+      const result = await api.process( headEvent );
+      partialDeepStrictEqual( result, {
+        statusCode: 200,
+        headers: {
+          'Content-Length': '42'
+        }
+      } );
+    } );
+  } );
 } );


### PR DESCRIPTION
## What
`LambdaApi.process()` short-circuited every `HEAD` request with a hardcoded `204 <empty>`, before handler matching even ran. Any handler registered with `method: 'HEAD'` was silently ignored.

## Fix
Move the `HEAD` short-circuit inside the "no handler matched" branch. If a `HEAD` handler is registered, it now runs like any other verb; if none is registered, behavior is unchanged (`204 <empty>`).

## Tests
- Added: default 204 when no HEAD handler is registered
- Added: registered HEAD handler is invoked and its response (status/headers) is used
- Full suite: 380/380 passing
- Lint: clean

## Docs
Updated `docs/lambda_api/index.md` to describe the new precedence (registered handler > default 204).
